### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v3.3.0"
         },
         {
           "run": "(git gc || :)"
@@ -35,7 +35,7 @@
       "runs-on": "${{ matrix.os }}",
       "steps": [
         {
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v3.3.0"
         },
         {
           "run": "(git gc || :)"
@@ -63,13 +63,13 @@
       "runs-on": "ubuntu-latest",
       "steps": [
         {
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v3.3.0"
         },
         {
           "run": "(git gc || :)"
         },
         {
-          "uses": "jirutka/setup-alpine@v1",
+          "uses": "jirutka/setup-alpine@v1.1.1",
           "with": {
             "branch": "edge",
             "packages": "build-base ed perl util-linux yash"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,14 +17,14 @@
           }
         },
         {
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v3.3.0"
         },
         {
           "run": "(git gc || :)"
         },
         {
           "name": "Initialise CodeQL",
-          "uses": "github/codeql-action/init@v2",
+          "uses": "github/codeql-action/init@codeql-bundle-20230105",
           "with": {
             "languages": "cpp"
           }
@@ -34,7 +34,7 @@
         },
         {
           "name": "Perform CodeQL Analysis",
-          "uses": "github/codeql-action/analyze@v2"
+          "uses": "github/codeql-action/analyze@codeql-bundle-20230105"
         }
       ],
       "strategy": {

--- a/.github/workflows/vm-dfbsd.yml
+++ b/.github/workflows/vm-dfbsd.yml
@@ -4,13 +4,13 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v3.3.0"
         },
         {
           "run": "(git gc || :)"
         },
         {
-          "uses": "vmactions/dragonflybsd-vm@v0",
+          "uses": "vmactions/dragonflybsd-vm@v0.0.6",
           "with": {
             "copyback": false,
             "mem": 2048,

--- a/.github/workflows/vm-nbsd.yml
+++ b/.github/workflows/vm-nbsd.yml
@@ -4,13 +4,13 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v3.3.0"
         },
         {
           "run": "(git gc || :)"
         },
         {
-          "uses": "vmactions/netbsd-vm@v0",
+          "uses": "vmactions/netbsd-vm@v0.1.0",
           "with": {
             "copyback": false,
             "mem": 2048,

--- a/.github/workflows/vm-obsd.yml
+++ b/.github/workflows/vm-obsd.yml
@@ -4,13 +4,13 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v3.3.0"
         },
         {
           "run": "(git gc || :)"
         },
         {
-          "uses": "vmactions/openbsd-vm@v0",
+          "uses": "vmactions/openbsd-vm@v0.1.1",
           "with": {
             "copyback": false,
             "mem": 2048,

--- a/.github/workflows/vm-slowlartus.yml
+++ b/.github/workflows/vm-slowlartus.yml
@@ -4,13 +4,13 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v3.3.0"
         },
         {
           "run": "(git gc || :)"
         },
         {
-          "uses": "vmactions/solaris-vm@v0",
+          "uses": "vmactions/solaris-vm@v0.0.9",
           "with": {
             "copyback": false,
             "mem": 2048,


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[vmactions/openbsd-vm](https://github.com/vmactions/openbsd-vm)** published a new release **[v0.1.1](https://github.com/vmactions/openbsd-vm/releases/tag/v0.1.1)** on 2022-11-02T15:21:24Z
* **[vmactions/netbsd-vm](https://github.com/vmactions/netbsd-vm)** published a new release **[v0.1.0](https://github.com/vmactions/netbsd-vm/releases/tag/v0.1.0)** on 2022-11-05T11:02:56Z
* **[vmactions/solaris-vm](https://github.com/vmactions/solaris-vm)** published a new release **[v0.0.9](https://github.com/vmactions/solaris-vm/releases/tag/v0.0.9)** on 2022-11-02T15:22:26Z
* **[jirutka/setup-alpine](https://github.com/jirutka/setup-alpine)** published a new release **[v1.1.1](https://github.com/jirutka/setup-alpine/releases/tag/v1.1.1)** on 2022-08-20T22:30:30Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230105](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230105)** on 2023-01-06T15:03:08Z
* **[vmactions/dragonflybsd-vm](https://github.com/vmactions/dragonflybsd-vm)** published a new release **[v0.0.6](https://github.com/vmactions/dragonflybsd-vm/releases/tag/v0.0.6)** on 2022-11-02T15:22:55Z
