### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@
         },
         {
           "name": "Initialise CodeQL",
-          "uses": "github/codeql-action/init@codeql-bundle-20230105",
+          "uses": "github/codeql-action/init@codeql-bundle-20230304",
           "with": {
             "languages": "cpp"
           }
@@ -34,7 +34,7 @@
         },
         {
           "name": "Perform CodeQL Analysis",
-          "uses": "github/codeql-action/analyze@codeql-bundle-20230105"
+          "uses": "github/codeql-action/analyze@codeql-bundle-20230304"
         }
       ],
       "strategy": {

--- a/.github/workflows/vm-dfbsd.yml
+++ b/.github/workflows/vm-dfbsd.yml
@@ -10,7 +10,7 @@
           "run": "(git gc || :)"
         },
         {
-          "uses": "vmactions/dragonflybsd-vm@v0.0.6",
+          "uses": "vmactions/dragonflybsd-vm@v0.0.7",
           "with": {
             "copyback": false,
             "mem": 2048,


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[vmactions/dragonflybsd-vm](https://github.com/vmactions/dragonflybsd-vm)** published a new release **[v0.0.7](https://github.com/vmactions/dragonflybsd-vm/releases/tag/v0.0.7)** on 2023-02-20T07:47:06Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230304](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230304)** on 2023-03-05T04:27:05Z
