### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"
@@ -35,7 +35,7 @@
       "runs-on": "${{ matrix.os }}",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"
@@ -63,7 +63,7 @@
       "runs-on": "ubuntu-latest",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,14 +17,14 @@
           }
         },
         {
-          "uses": "actions/checkout@v3.5.0"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"
         },
         {
           "name": "Initialise CodeQL",
-          "uses": "github/codeql-action/init@v2",
+          "uses": "github/codeql-action/init@codeql-bundle-20230524",
           "with": {
             "languages": "cpp"
           }
@@ -34,7 +34,7 @@
         },
         {
           "name": "Perform CodeQL Analysis",
-          "uses": "github/codeql-action/analyze@v2"
+          "uses": "github/codeql-action/analyze@codeql-bundle-20230524"
         }
       ],
       "strategy": {

--- a/.github/workflows/vm-dfbsd.yml
+++ b/.github/workflows/vm-dfbsd.yml
@@ -4,7 +4,7 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"

--- a/.github/workflows/vm-nbsd.yml
+++ b/.github/workflows/vm-nbsd.yml
@@ -4,7 +4,7 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"

--- a/.github/workflows/vm-obsd.yml
+++ b/.github/workflows/vm-obsd.yml
@@ -4,7 +4,7 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"

--- a/.github/workflows/vm-slowlartus.yml
+++ b/.github/workflows/vm-slowlartus.yml
@@ -4,7 +4,7 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.3](https://github.com/actions/checkout/releases/tag/v3.5.3)** on 2023-06-09T15:05:56Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230524](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230524)** on 2023-05-24T16:01:13Z
